### PR TITLE
App delegate cleanup

### DIFF
--- a/iOS/MobileStarter/MobileStarter/AppDelegate.swift
+++ b/iOS/MobileStarter/MobileStarter/AppDelegate.swift
@@ -10,21 +10,6 @@ import ITwinMobile
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Customize the ITMViewController used by the sample app. Note that since this sample
-        // puts all of the UI inside a full-screen WKWebView, it has no customization to the
-        // view controller, and simply uses the ITMViewController in its storyboard.
-        
-        // Use our ModelApplication (a subclass of ITMApplication) as the application object.
-        ITMViewController.application = ModelApplication()
-        // Delay the automatic loading of the frontend and backend to account for problem when
-        // that happens before the application's first willEnterForeground.
-        // Note that the sequence of events is different prior to iOS 13, so only do this in
-        // iOS 13 and later.
-        ITMViewController.delayedAutoLoad = true
-        return true
-    }
-
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
@@ -37,11 +22,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-    
-    func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        // Note: This only gets called in iOS prior to 13.
-        DocumentHelper.openInboxUrl(url)
-        return true
     }
 }

--- a/iOS/MobileStarter/MobileStarter/SceneDelegate.swift
+++ b/iOS/MobileStarter/MobileStarter/SceneDelegate.swift
@@ -17,20 +17,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
         
-            // Use our ModelApplication (a subclass of ITMApplication) as the application object.
+        // Use our ModelApplication (a subclass of ITMApplication) as the application object.
         ITMViewController.application = ModelApplication()
 
-        if #available(iOS 13, *) {
-            // Delay the automatic loading of the frontend and backend to account for problem when
-            // that happens before the application's first willEnterForeground.
-            // Note that the sequence of events is different prior to iOS 13, so only do this in
-            // iOS 13 and later.
-            ITMViewController.delayedAutoLoad = true
-        }
+        // Delay the automatic loading of the frontend and backend to account for problem when
+        // that happens before the application's first willEnterForeground.
+        ITMViewController.delayedAutoLoad = true
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        // Note: This only gets called in iOS 13 and later.
         if let url = URLContexts.first?.url {
             DocumentHelper.openInboxUrl(url)
         }


### PR DESCRIPTION
Removed unnecessary code now that we require iOS 13. Also removed ModelApplication initialization from AppDelegate as it will always be done in the SceneDelegate.