### PR TITLE
Automate handling of ITMAppConfig.json settings.

### DIFF
--- a/iOS/Shared/ModelApplication.swift
+++ b/iOS/Shared/ModelApplication.swift
@@ -12,6 +12,9 @@ import ShowTime
 
 /// This app's `ITMApplication` sub-class that handles the messages coming from the web view.
 class ModelApplication: ITMApplication {
+    private var debugI18n = false
+    private var lowResolution = false
+
     /// Registers query handlers.
     required init() {
         super.init()
@@ -47,11 +50,28 @@ class ModelApplication: ITMApplication {
     }
     
     override func loadITMAppConfig() -> JSON? {
-        let config = super.loadITMAppConfig()
-        let showtimeEnableValue = config?["showtimeEnabled"] as? String ?? "NO"
-        if showtimeEnableValue != "YES" {
+        let configData = super.loadITMAppConfig()
+        var showtimeEnabled = false
+        if let configData = configData {
+            extractConfigDataToEnv(configData: configData, "ITMSAMPLE_");
+            debugI18n = configData["ITMSAMPLE_DEBUG_I18N"] as? String == "YES"
+            lowResolution = configData["ITMSAMPLE_LOW_RESOLUTION"] as? String == "YES"
+            showtimeEnabled = configData["ITMSAMPLE_SHOWTIME_ENABLED"] as? String == "YES"
+        }
+        if !showtimeEnabled {
             ShowTime.enabled = ShowTime.Enabled.never
         }
-        return config
+        return configData
+    }
+    
+    override func getUrlHashParams() -> String {
+        var hashParams = ""
+        if debugI18n {
+            hashParams += "&debugI18n=YES"
+        }
+        if lowResolution {
+            hashParams += "&lowResolution=YES"
+        }
+        return hashParams
     }
 }

--- a/iOS/iOSSamples.xcconfig
+++ b/iOS/iOSSamples.xcconfig
@@ -15,16 +15,6 @@
 // en0, set the following to the name of the device to use.
 // ITMAPPLICATION_SERVER_DEVICE
 //
-// Set the following setting if you want to put delimiters around the app's localized strings.
-// ITM_DEBUG_I18N = YES
-//
-// Set the following setting if you want the model to display in low resolution. If you are
-// running on a Simulator with iOS before iOS 15, it is HIGHLY recommended that you set this.
-// ITM_LOW_RESOLUTION = YES
-//
-// Set the following setting if you want to enable ShowTime tap visibility:
-// ITM_SHOWTIME_ENABLED = YES
-//
 // If you want to run the built app locally on the device instead of using the React debug
 // server, set the following:
 // ITMAPPLICATION_NO_DEBUG_SERVER = YES
@@ -32,3 +22,13 @@
 // Other supported ITMApplication settings:
 // ITMAPPLICATION_ISSUER_URL
 // ITMAPPLICATION_REDIRECT_URI
+//
+// Set the following setting if you want to put delimiters around the app's localized strings.
+// ITMSAMPLE_DEBUG_I18N = YES
+//
+// Set the following setting if you want the model to display in low resolution. If you are
+// running on a Simulator with iOS before iOS 15, it is HIGHLY recommended that you set this.
+// ITMSAMPLE_LOW_RESOLUTION = YES
+//
+// Set the following setting if you want to enable ShowTime tap visibility:
+// ITMSAMPLE_SHOWTIME_ENABLED = YES


### PR DESCRIPTION
There is a PR on iTwin/mobile-sdk-ios with the same name. These two PRs must be used together.