### PR TITLE
Match functionality on Windows in webpack config

### DIFF
--- a/cross-platform/react-app/webpack.config.js
+++ b/cross-platform/react-app/webpack.config.js
@@ -46,10 +46,11 @@ function getConfig(env) {
     // don't really use, but trigger exceptions at run-time in their startup
     // initialization.
     module: {
-      rules: [{
-        test: /formidable\/.*js$/,
-        use: 'null-loader'
-      },
+      rules: [
+	    {
+          test: /formidable(\\|\/).*js$/,
+          use: 'null-loader'
+        },
         // {
         //   test: /backend-itwin-client/,
         //   use: 'null-loader'


### PR DESCRIPTION
Modified the webpack config to match functionality on Windows and skip bundling the `formidable` dependency that causes an error when loading the backend. This gets the Windows build functional 🙂