### PR TITLE
Use typescript version from workspace in VS code

### DIFF
--- a/cross-platform/react-app/.vscode/settings.json
+++ b/cross-platform/react-app/.vscode/settings.json
@@ -25,5 +25,6 @@
         "typedoc",
         "webgl",
         "xcconfig"
-    ]
+    ],
+    "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
Visual Studio Code was complaining about not being able to find div elements in tsx files. The root cause turned out to be due to it using a newer version of TypeScript than the project itself. This fixes that (when running vs code for the cross-platform/react-app directory).