### PR TITLE
Give each Android sample a unique auth URI scheme

### DIFF
--- a/Android/CameraSample/app/build.gradle
+++ b/Android/CameraSample/app/build.gradle
@@ -3,18 +3,20 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+project.parent.ext.redirect_uri_scheme = "com.bentley.sample.camera"
+
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.bentley.sample.camera"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders = ['appAuthRedirectScheme': 'imodeljs']
+        manifestPlaceholders = ['appAuthRedirectScheme': "${project.parent.redirect_uri_scheme}"]
     }
 
     buildTypes {
@@ -37,19 +39,18 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
-    implementation "androidx.activity:activity-ktx:1.5.1"
+    implementation "androidx.activity:activity-ktx:1.6.0"
     implementation 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     implementation project(path: ':itmsamplesshared')
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    releaseImplementation 'com.github.itwin:mobile-sdk-android:0.10.31'
-    debugImplementation 'com.github.itwin:mobile-sdk-android:0.10.31-debug'
+    implementation 'com.github.itwin:mobile-sdk-android:0.10.32'
 }
 
 preBuild.dependsOn ":itmsamplesshared:genITMAppConfig"

--- a/Android/CameraSample/app/src/main/AndroidManifest.xml
+++ b/Android/CameraSample/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.ITwinStarter"
-        tools:targetApi="31"
+        tools:targetApi="33"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name="com.bentley.sample.shared.MainActivity"

--- a/Android/README.md
+++ b/Android/README.md
@@ -6,7 +6,20 @@ These samples make use of the iTwin [`mobile-sdk-android`](https://github.com/iT
 
 ## Client ID Setup
 
-Before building the samples, you must configure a Client ID for yourself. To do so, follow the instructions [here](../cross-platform/ClientID.md).
+Before running any samples, you must configure a Client ID for yourself. To do so, follow the instructions [here](../cross-platform/ClientID.md).
+
+### Android-specific Client IDs
+
+For the Android samples, you need to create a custom redirect URI for each one that you want to run. To do that:
+
+1. Go to <https://developer.bentley.com/my-apps/>.
+1. Select the application that you created above.
+1. Hit the `+` to the right of the last Redirect URI.
+1. Enter the sample-specific redirect URI. The URIs are:
+    * iTwinStarter: `com.bentley.sample.itwinstarter://app/signin-callback`
+    * CameraSample: `com.bentley.sample.camera://app/signin-callback`
+    * ThirdPartyAuth: `com.bentley.sample.thirdpartyauth://app/signin-callback`
+1. Hit `Save`.
 
 ## ITMSamples.properties Setup
 

--- a/Android/Shared/ITMAppConfig.gradle
+++ b/Android/Shared/ITMAppConfig.gradle
@@ -64,6 +64,9 @@ static def readITMAppConfig (project) {
         }
         contents["ITMAPPLICATION_BASE_URL"] = "http://${appHost}:${debugPort}"
     }
+    if (project.parent.hasProperty("redirect_uri_scheme")) {
+        contents['ITMAPPLICATION_REDIRECT_URI'] = "${project.parent.redirect_uri_scheme}://app/signin-callback"
+    }
     extractProperties(properties, "itmapplication", contents)
     extractProperties(properties, "itmsample", contents)
     return contents

--- a/Android/Shared/build.gradle
+++ b/Android/Shared/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         minSdk 24
-        targetSdk 32
+        targetSdk 33
 
         // testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -31,8 +31,8 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
     implementation 'com.eclipsesource.minimal-json:minimal-json:0.9.5'

--- a/Android/ThirdPartyAuth/app/build.gradle
+++ b/Android/ThirdPartyAuth/app/build.gradle
@@ -3,13 +3,15 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+project.parent.ext.redirect_uri_scheme = "com.bentley.sample.thirdpartyauth"
+
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
-        applicationId "com.bentley.sample.ThirdPartyAuth"
+        applicationId "com.bentley.sample.thirdpartyauth"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -18,7 +20,7 @@ android {
             useSupportLibrary true
         }
         manifestPlaceholders = [
-                'appAuthRedirectScheme': 'imodeljs',
+                'appAuthRedirectScheme': "${project.parent.redirect_uri_scheme}",
                 'auth0Domain'          : '@string/ITMSAMPLE_AUTH0_DOMAIN',
                 'auth0Scheme'          : '@string/ITMSAMPLE_AUTH0_SCHEME'
         ]
@@ -52,15 +54,15 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.5.0'
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation 'androidx.activity:activity-compose:1.6.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
@@ -75,7 +77,7 @@ dependencies {
     implementation 'com.auth0.android:auth0:2.8.0'
     implementation 'com.auth0.android:jwtdecode:2.0.1'
 
-    implementation 'com.github.itwin:mobile-sdk-android:0.10.31'
+    implementation 'com.github.itwin:mobile-sdk-android:0.10.32'
 }
 
 apply from: "$rootDir/../Shared/ITMAppConfig.gradle"

--- a/Android/iTwinStarter/app/build.gradle
+++ b/Android/iTwinStarter/app/build.gradle
@@ -3,18 +3,20 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+project.parent.ext.redirect_uri_scheme = "com.bentley.sample.itwinstarter"
+
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.bentley.sample.itwinstarter"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders = ['appAuthRedirectScheme': 'imodeljs']
+        manifestPlaceholders = ['appAuthRedirectScheme': "${project.parent.redirect_uri_scheme}"]
     }
 
     buildTypes {
@@ -37,12 +39,12 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
-    implementation "androidx.activity:activity-ktx:1.5.1"
+    implementation "androidx.activity:activity-ktx:1.6.0"
     implementation 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     implementation project(path: ':itmsamplesshared')
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
Having them all uses "imodeljs" as in iOS causes a problem in Android: if multiple samples are installed, the user is asked which one to apply the sign in to each time they sign in. They could choose to always apply to that sample, but that would then mean that the others would no longer work. This scheme needs to be unique in Android, so I updated the samples to use their own application ID as their URI scheme.