### PR TITLE
Fix Android code inspection warning

### DIFF
--- a/Android/Shared/src/main/java/com/bentley/sample/shared/PickUriContract.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/PickUriContract.kt
@@ -18,7 +18,7 @@ typealias PickUriContractType = ActivityResultContract<JsonValue?, Uri?>
  * @property destDir The optional external files directory to copy the Uri to.
  *                   Must be non-null and [shouldCopyUri] must return true for the copying to occur.
  */
-open class PickUriContract(var destDir: String? = null) : PickUriContractType() {
+open class PickUriContract(@Suppress("MemberVisibilityCanBePrivate") var destDir: String? = null) : PickUriContractType() {
     protected lateinit var context: Context
 
     /**


### PR DESCRIPTION
Note: this code inspection warning doesn't happen in CameraSample since it modifies the value externally. Since the other samples don't, they produce a warning.