### PR TITLE
Update Android minSdk from 24 to 28.

### DIFF
--- a/Android/CameraSample/app/build.gradle
+++ b/Android/CameraSample/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.bentley.sample.camera"
-        minSdk 24
+        minSdk 28
         targetSdk 33
         versionCode 1
         versionName "1.0"

--- a/Android/Shared/build.gradle
+++ b/Android/Shared/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        minSdk 24
+        minSdk 28
         targetSdk 33
 
         // testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/MainActivity.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/MainActivity.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Color
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.view.ViewGroup
 import android.view.Window
@@ -87,9 +86,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun setupFullScreen() {
         // Truly full screen (including camera cutouts)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-        }
+        window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.statusBarColor = Color.TRANSPARENT

--- a/Android/ThirdPartyAuth/app/build.gradle
+++ b/Android/ThirdPartyAuth/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.bentley.sample.thirdpartyauth"
-        minSdk 24
+        minSdk 28
         targetSdk 33
         versionCode 1
         versionName "1.0"

--- a/Android/iTwinStarter/app/build.gradle
+++ b/Android/iTwinStarter/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.bentley.sample.itwinstarter"
-        minSdk 24
+        minSdk 28
         targetSdk 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
After consultation with the SYNCHRO team, it was decided that SDK 28 is the new minimum SDK for Android.