### PR TITLE
Skip point-to-point network interfaces when determining the IP

### DIFF
--- a/Android/Shared/ITMAppConfig.gradle
+++ b/Android/Shared/ITMAppConfig.gradle
@@ -9,7 +9,7 @@ import groovy.json.JsonOutput
 static def getLocalIPv4() {
     def ip4s = []
     NetworkInterface.getNetworkInterfaces()
-        .findAll { it.isUp() && !it.isLoopback() && !it.isVirtual() }
+        .findAll { it.isUp() && !it.isLoopback() && !it.isVirtual() && !it.isPointToPoint() }
         .each {
             it.getInetAddresses()
                 .findAll { !it.isLoopbackAddress() && it instanceof Inet4Address }


### PR DESCRIPTION
I noticed it was using my VPN IP address when trying to get my computer's IP address.