### PR TITLE
Use Localization.getLocalizedString instead of getLocalizedStrinWithNamespace.

### DIFF
--- a/cross-platform/react-app/src/frontend/CameraSample/CameraSampleApp.tsx
+++ b/cross-platform/react-app/src/frontend/CameraSample/CameraSampleApp.tsx
@@ -15,9 +15,9 @@ import {
 
 export function CameraSampleAppGetLocalizedString(prefix: string, key: string, options?: any) {
   if (window.itmSampleParams.debugI18n) {
-    return `=${IModelApp.localization.getLocalizedStringWithNamespace("CameraSampleApp", `${prefix}.${key}`, options)}=`;
+    return `=${IModelApp.localization.getLocalizedString(`CameraSampleApp:${prefix}.${key}`, options)}=`;
   } else {
-    return IModelApp.localization.getLocalizedStringWithNamespace("CameraSampleApp", `${prefix}.${key}`, options);
+    return IModelApp.localization.getLocalizedString(`CameraSampleApp:${prefix}.${key}`, options);
   }
 }
 

--- a/cross-platform/react-app/src/frontend/Components/Screen.tsx
+++ b/cross-platform/react-app/src/frontend/Components/Screen.tsx
@@ -20,9 +20,9 @@ export interface ScreenProps {
 
 export function i18n(prefix: string, key: string, options?: any) {
   if (window.itmSampleParams.debugI18n) {
-    return `=${IModelApp.localization.getLocalizedStringWithNamespace("ReactApp", `${prefix}.${key}`, options)}=`;
+    return `=${IModelApp.localization.getLocalizedString(`ReactApp:${prefix}.${key}`, options)}=`;
   } else {
-    return IModelApp.localization.getLocalizedStringWithNamespace("ReactApp", `${prefix}.${key}`, options);
+    return IModelApp.localization.getLocalizedString(`ReactApp:${prefix}.${key}`, options);
   }
 }
 


### PR DESCRIPTION
The latter is deprecated in future versions of iTwin.js.