### PR TITLE
Provide examples of query sending.

### DIFF
--- a/cross-platform/react-app/src/frontend/App.tsx
+++ b/cross-platform/react-app/src/frontend/App.tsx
@@ -143,6 +143,10 @@ function useAppState(onInitialize?: () => Promise<void>) {
         // Switch from the Loading screen to the Home screen.
         pushActiveInfo(ActiveScreen.Home);
         console.log("...Done Initializing.");
+        Messenger.onQuery("queryExample").setHandler(async (params) => params.value);
+        Messenger.onQuery("oneWayExample").setHandler(async (params) => {
+          console.log(`oneWayExample received value: ${params.value}`);
+        });
       } catch (ex) {
         console.log(`Exception during initialization: ${ex}`);
       }

--- a/iOS/Shared/ModelApplication.swift
+++ b/iOS/Shared/ModelApplication.swift
@@ -48,6 +48,38 @@ class ModelApplication: ITMApplication {
         if !showtimeEnabled {
             ShowTime.enabled = ShowTime.Enabled.never
         }
+        oneWayExample("one way")
+        // Note that since these all run concurrently, there is no guarantee that the responses
+        // will come back in the same order that they are sent below.
+        queryExample("string query")
+        queryExample(42)
+        queryExample(1.234)
+        queryExample(true)
+    }
+
+    /// Example showing how to send a message with a value to the web app with no response expected.
+    /// - Parameter value: A value to be sent to the web app and returned back. It must be of a type supported by
+    ///                    the native <-> JavaScript interop layer.
+    func oneWayExample<T>(_ value: T) {
+        // Note: because we don't wait for any response, if there is a failure (like the web app
+        // does not have a handler for the message), the app won't know (although ITMMessenger will
+        // log an error).
+        itmMessenger.query("oneWayExample", ["value": value])
+        Self.logger.log(.debug, "oneWayExample message sent.")
+    }
+
+    /// Example showing how to send a message with a value to the web app, and receive a response.
+    /// - Parameter value: A value to be sent to the web app and returned back. It must be of a type supported by
+    ///                    the native <-> JavaScript interop layer.
+    func queryExample<T>(_ value: T) {
+        Task {
+            do {
+                let result: T = try await itmMessenger.query("queryExample", ["value": value])
+                Self.logger.log(.debug, "queryExample result \(result)")
+            } catch {
+                Self.logger.log(.error, "Error with queryExample: \(error)")
+            }
+        }
     }
 
     override func loadBackend(_ allowInspectBackend: Bool) {


### PR DESCRIPTION
These query examples provide two independent improvements to the code:

1. Since the only place in the base sample that we send a query is when opening a BIM file from another app, it lets people see queries running.
2. A race condition was recently discovered and corrected in the message sending code. Had these query examples been present, that race condition would have been fixed long ago. Having them here now insures that no similar race conditions will be introduced in the future.