### PR TITLE
Add folder icon as SVG example.

### DIFF
--- a/cross-platform/react-app/src/frontend/Components/Button.tsx
+++ b/cross-platform/react-app/src/frontend/Components/Button.tsx
@@ -10,10 +10,12 @@ import "./Button.scss";
 export interface ButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   /// The title of the button.
   title: string;
+  /// Optional react node to put to the left of the title, intended to contain an icon.
+  icon?: React.ReactNode;
 }
 
 /// Extremely basic text button React component.
 export function Button(props: ButtonProps) {
-  const { className, title, children, ...others } = props;
-  return <div className={classnames("Button", className)} {...others}>{title}{children}</div>;
+  const { className, title, icon, children, ...others } = props;
+  return <div className={classnames("Button", className)} {...others}>{icon}{title}{children}</div>;
 }

--- a/cross-platform/react-app/src/frontend/Images/folder.svg
+++ b/cross-platform/react-app/src/frontend/Images/folder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="1rem" height="1rem"><path d="M8 3L6.586 1.586A2 2 0 005.17 1H1a1 1 0 00-1 1v3h16V4a1 1 0 00-1-1z" fill="#e7b93a"/><path d="M0 14a1 1 0 001 1h14a1 1 0 001-1V5H0z" fill="#f6d97a"/></svg>

--- a/cross-platform/react-app/src/frontend/Screens/HomeScreen.tsx
+++ b/cross-platform/react-app/src/frontend/Screens/HomeScreen.tsx
@@ -3,10 +3,18 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import React from "react";
+import { IconSpecUtilities } from "@itwin/appui-abstract";
 import { Messenger } from "@itwin/mobile-sdk-core";
-import { BackButton } from "@itwin/mobile-ui-react";
+import { BackButton, IconImage } from "@itwin/mobile-ui-react";
 import { Button, i18n, Screen } from "../Exports";
 import "./HomeScreen.scss";
+
+// With svg.d.ts present in the root of this project, Webpack automatically handles the import below
+// by having folderSvg be the path to the name-mangled version of folder.svg.
+import folderSvg from "../Images/folder.svg";
+// IconSpecUtilities.createWebComponentIconSpec takes the SVG path and tweaks it for use in any
+// place that expects an IconSpec.
+const folderIconSpec = IconSpecUtilities.createWebComponentIconSpec(folderSvg);
 
 export enum ActiveScreen {
   Loading,
@@ -42,7 +50,10 @@ export function HomeScreen(props: HomeScreenProps) {
       </div>
       <div className="list">
         <div className="list-items">
-          <Button title={localModelsLabel} onClick={() => onSelect(ActiveScreen.LocalModels)} />
+          <Button
+            icon={<IconImage iconSpec={folderIconSpec} margin="0px 8px 0px 0px" size="32px" />}
+            title={localModelsLabel}
+            onClick={() => onSelect(ActiveScreen.LocalModels)} />
           <Button title={hubIModelsLabel} onClick={() => onSelect(ActiveScreen.Hub)} />
         </div>
       </div>

--- a/cross-platform/react-app/src/frontend/svg.d.ts
+++ b/cross-platform/react-app/src/frontend/svg.d.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+// The mere presence of this file allows *.svg files to be imported as strings that then get
+// converted to IconSpec values using IconSpecUtilities.createWebComponentIconSpec.
+// DO NOT import or export this file from anywhere.
+
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
The main reason for this PR is to show users how to include custom SVG images in their iTwin Mobile-based applications.