### PR TITLE
Don't fetch while already fetching

### DIFF
--- a/cross-platform/react-app/src/frontend/Exports.tsx
+++ b/cross-platform/react-app/src/frontend/Exports.tsx
@@ -25,3 +25,4 @@ export * from "./Screens/Hub/HubScreen";
 export * from "./BottomPanels/ElementPropertiesPanel";
 export * from "./BottomPanels/ToolsBottomPanel";
 export * from "./Components/SearchControl";
+export * from "../common/PromiseUtil";

--- a/cross-platform/react-app/src/frontend/Screens/Hub/IModelPicker.tsx
+++ b/cross-platform/react-app/src/frontend/Screens/Hub/IModelPicker.tsx
@@ -10,7 +10,7 @@ import { IModelApp, NativeApp } from "@itwin/core-frontend";
 import { IModelsClient, MinimalIModel } from "@itwin/imodels-client-management";
 import { AccessTokenAdapter } from "@itwin/imodels-access-frontend";
 import { LocalBriefcaseProps } from "@itwin/core-common";
-import { ButtonProps, fileSizeString, HubScreenButton, HubScreenButtonList, HubScreenButtonListProps, i18n, presentError } from "../../Exports";
+import { ButtonProps, fileSizeString, HubScreenButton, HubScreenButtonList, HubScreenButtonListProps, i18n, presentError, PromiseUtil } from "../../Exports";
 
 export interface IModelInfo {
   minimalIModel: MinimalIModel;
@@ -130,7 +130,7 @@ export function IModelPicker(props: IModelPickerProps) {
       }
       setLoading(false);
     };
-    void fetchModels();
+    void PromiseUtil.consolidateCall(`fetchModels-${project.id}`, async () => fetchModels());
   }, [isMountedRef, onError, onLoaded, project]);
 
   return <IModelList models={iModels} loading={loading} onSelect={onSelect} onCacheDeleted={(model) => {

--- a/cross-platform/react-app/src/frontend/Screens/Hub/ProjectPicker.tsx
+++ b/cross-platform/react-app/src/frontend/Screens/Hub/ProjectPicker.tsx
@@ -7,7 +7,7 @@ import { HorizontalPicker, useIsMountedRef } from "@itwin/mobile-ui-react";
 import { Project, ProjectsAccessClient, ProjectsQueryArg, ProjectsQueryFunction, ProjectsSearchableProperty, ProjectsSource } from "@itwin/projects-client";
 import { IModelApp } from "@itwin/core-frontend";
 import { LoadingSpinner } from "@itwin/core-react";
-import { ButtonProps, HubScreenButton, HubScreenButtonList, HubScreenButtonListProps, i18n, presentError, SearchControl } from "../../Exports";
+import { ButtonProps, HubScreenButton, HubScreenButtonList, HubScreenButtonListProps, i18n, presentError, PromiseUtil, SearchControl } from "../../Exports";
 
 async function getProjects(source = ProjectsSource.All, searchString = "") {
   const baseUrl = `https://${window.itmSampleParams.apiPrefix}api.bentley.com/projects/`;
@@ -91,7 +91,7 @@ export function ProjectPicker(props: ProjectPickerProps) {
       }
       setLoading(false);
     };
-    void fetchProjects();
+    void PromiseUtil.consolidateCall("fetchProjects", async () => fetchProjects());
   }, [isMountedRef, onError, projectSource, search]);
 
   const loadMore = React.useCallback(async () => {


### PR DESCRIPTION
Due to the way React Hooks work, the list of iModels and Projects both got fetched twice when they were only intended to be fetched once. This uses PromiseUtil.consolidatedCall to prevent a fetch from happening when an identical fetch is already in progress.