### PR TITLE
More changes to make application integration easier

### DIFF
--- a/Android/CameraSample/.idea/detekt.xml
+++ b/Android/CameraSample/.idea/detekt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DetektPluginSettings">
+    <option name="enableDetekt" value="false" />
+  </component>
+</project>

--- a/Android/CameraSample/app/src/main/AndroidManifest.xml
+++ b/Android/CameraSample/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         tools:targetApi="33"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
-            android:name="com.bentley.sample.shared.MainActivity"
+            android:name="CameraMainActivity"
             android:configChanges="orientation|screenSize|keyboard|keyboardHidden|layoutDirection|locale|fontScale|uiMode"
             android:exported="true">
             <intent-filter>

--- a/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraApplication.kt
+++ b/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraApplication.kt
@@ -4,30 +4,21 @@
 *--------------------------------------------------------------------------------------------*/
 package com.bentley.sample.camera
 
-import android.app.Application
 import android.content.Context
-import com.bentley.sample.shared.MainActivity
+import com.bentley.sample.shared.SampleApplicationBase
 
-/**
- * [Application] sub-class for this sample.
- */
-class CameraApplication: Application() {
-    /**
-     * Sets [MainActivity.sampleITMApplication] to [CameraITMApplication] so that our camera-specific message handlers are setup.
-     */
-    override fun onCreate() {
-        super.onCreate()
-        appContext = applicationContext
-        application = this
-        MainActivity.sampleITMApplication = CameraITMApplication
-    }
-
-    companion object {
-        private lateinit var appContext: Context
-        private lateinit var application: Application
-
-        fun getContext() : Context {
-            return appContext
+class CameraApplication: SampleApplicationBase<CameraITMApplication>({
+    object: CameraITMApplication(it) {
+        init {
+            finishInit()
         }
+    }
+}) {
+    companion object {
+        lateinit var instance: CameraApplication
+            private set
+    }
+    init {
+        CameraApplication.instance = this
     }
 }

--- a/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraITMApplication.kt
+++ b/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraITMApplication.kt
@@ -4,20 +4,17 @@
 *--------------------------------------------------------------------------------------------*/
 package com.bentley.sample.camera
 
+import android.content.Context
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
-import com.bentley.sample.shared.MainActivity
+import androidx.activity.ComponentActivity
 import com.bentley.sample.shared.SampleITMApplication
 
 /**
  * [SampleITMApplication] sub-class that sets up all of the camera-specific functionality.
  */
-object CameraITMApplication : SampleITMApplication(CameraApplication.getContext(), BuildConfig.DEBUG, BuildConfig.DEBUG) {
-    init {
-        finishInit()
-    }
-
+open class CameraITMApplication(context: Context) : SampleITMApplication(context, BuildConfig.DEBUG, BuildConfig.DEBUG) {
     /**
      * Registers handlers for the camera-specific messages.
      */
@@ -39,7 +36,7 @@ object CameraITMApplication : SampleITMApplication(CameraApplication.getContext(
     /**
      * Registers activity result handlers for our native UI components including [ImagePicker].
      */
-    override fun onCreateActivity(activity: MainActivity) {
+    override fun onCreateActivity(activity: ComponentActivity) {
         super.onCreateActivity(activity)
         ImagePicker.registerForActivityResult(activity)
     }
@@ -49,8 +46,8 @@ object CameraITMApplication : SampleITMApplication(CameraApplication.getContext(
      */
     override fun onRegisterNativeUI() {
         super.onRegisterNativeUI()
-        nativeUI?.let {
-            it.components.add(ImagePicker(it))
+        nativeUI?.apply {
+            components.add(ImagePicker(this))
         }
     }
 }

--- a/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraITMApplication.kt
+++ b/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraITMApplication.kt
@@ -10,6 +10,7 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import com.bentley.sample.shared.SampleITMApplication
+import com.github.itwin.mobilesdk.ITMNativeUI
 
 /**
  * [SampleITMApplication] sub-class that sets up all of the camera-specific functionality.
@@ -44,10 +45,8 @@ open class CameraITMApplication(context: Context) : SampleITMApplication(context
     /**
      * Registers our native UI components including [ImagePicker].
      */
-    override fun onRegisterNativeUI() {
-        super.onRegisterNativeUI()
-        nativeUI?.apply {
-            components.add(ImagePicker(this))
-        }
+    override fun onRegisterNativeUI(nativeUI: ITMNativeUI) {
+        super.onRegisterNativeUI(nativeUI)
+        nativeUI.components.add(ImagePicker(nativeUI))
     }
 }

--- a/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraMainActivity.kt
+++ b/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/CameraMainActivity.kt
@@ -4,20 +4,22 @@
 *--------------------------------------------------------------------------------------------*/
 package com.bentley.sample.camera
 
-import com.bentley.sample.shared.SampleApplicationBase
+import android.os.Bundle
+import com.bentley.sample.shared.MainActivity
 
-class CameraApplication: SampleApplicationBase<CameraITMApplication>({
-    object: CameraITMApplication(it) {
-        init {
-            finishInit()
-        }
-    }
-}) {
+class CameraMainActivity: MainActivity() {
     companion object {
-        lateinit var instance: CameraApplication
+        var current: CameraMainActivity? = null
             private set
     }
-    init {
-        instance = this
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        current = this
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        current = null
     }
 }

--- a/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/ImageCache.kt
+++ b/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/ImageCache.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.net.Uri
 import android.webkit.WebResourceResponse
 import androidx.core.content.FileProvider
-import com.bentley.sample.shared.MainActivity
 import com.bentley.sample.shared.getExternalFiles
 import com.eclipsesource.json.Json
 import com.eclipsesource.json.JsonValue
@@ -147,7 +146,7 @@ object ImageCache {
         }
 
         if (urls != null && urls.isNotEmpty()) {
-            MainActivity.current?.let {
+            CameraMainActivity.current?.let {
                 val shareIntent = Intent().apply {
                     type = "image/*"
                     action = Intent.ACTION_SEND_MULTIPLE

--- a/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/ImageCache.kt
+++ b/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/ImageCache.kt
@@ -8,8 +8,8 @@ import android.content.Intent
 import android.net.Uri
 import android.webkit.WebResourceResponse
 import androidx.core.content.FileProvider
-import com.bentley.sample.shared.FileHelper
 import com.bentley.sample.shared.MainActivity
+import com.bentley.sample.shared.getExternalFiles
 import com.eclipsesource.json.Json
 import com.eclipsesource.json.JsonValue
 import com.github.itwin.mobilesdk.ITMLogger
@@ -28,7 +28,7 @@ object ImageCache {
      * The base directory for cached images.
      */
     private val baseDir: String by lazy {
-        CameraITMApplication.appContext.getExternalFilesDir("images").toString()
+        CameraApplication.instance.applicationContext.getExternalFilesDir("images").toString()
     }
 
     /**
@@ -86,7 +86,7 @@ object ImageCache {
      * @return A Json array of cached images uri's, may be empty.
      */
     fun handleGetImages(params: JsonValue?): JsonValue? {
-        val files = FileHelper.getExternalFiles(CameraITMApplication.appContext, getDestinationDir(params))
+        val files = CameraApplication.instance.applicationContext.getExternalFiles(getDestinationDir(params))
         return Json.array(*files.map { file ->
             getCacheUri(file).toString()
         }.toTypedArray())
@@ -118,7 +118,7 @@ object ImageCache {
             getFilePath(Uri.parse(fileName)).takeIf { it.exists() }?.delete()
         } catch (e: Exception) {
             e.message?.let {
-                CameraITMApplication.logger.log(ITMLogger.Severity.Error, it)
+                CameraApplication.instance.itmApplication.logger.log(ITMLogger.Severity.Error, it)
             }
         }
     }
@@ -143,7 +143,7 @@ object ImageCache {
     fun handleShareImages(params: JsonValue?): JsonValue? {
         val urls = getObjectValue(params, "urls")?.asArray()?.map {
             val file = getFilePath(Uri.parse(it.asString()))
-            FileProvider.getUriForFile(CameraITMApplication.appContext, "${BuildConfig.APPLICATION_ID}.provider", file)
+            FileProvider.getUriForFile(CameraApplication.instance.applicationContext, "${BuildConfig.APPLICATION_ID}.provider", file)
         }
 
         if (urls != null && urls.isNotEmpty()) {

--- a/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/ImagePicker.kt
+++ b/Android/CameraSample/app/src/main/java/com/bentley/sample/camera/ImagePicker.kt
@@ -7,10 +7,10 @@ package com.bentley.sample.camera
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import com.bentley.sample.shared.PickUriContract
 import com.bentley.sample.shared.PickUriContractType
@@ -173,7 +173,7 @@ class ImagePicker(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI) {
         /**
          * Registers a request to start an activity for result using the [PickOrCaptureIModelImageContract].
          */
-        fun registerForActivityResult(activity: AppCompatActivity) {
+        fun registerForActivityResult(activity: ComponentActivity) {
             startForResult = activity.registerForActivityResult(PickOrCaptureIModelImageContract()) { uri ->
                 activeContinuation?.resumeWith(Result.success(Json.value(uri?.toString() ?: "")))
                 activeContinuation = null

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/DocumentPicker.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/DocumentPicker.kt
@@ -9,8 +9,8 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
-import androidx.appcompat.app.AppCompatActivity
 import com.eclipsesource.json.Json
 import com.eclipsesource.json.JsonValue
 import com.github.itwin.mobilesdk.ITMNativeUI
@@ -79,7 +79,7 @@ class DocumentPicker(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI) {
         /**
          * Registers a request to start an activity for result using the [PickDocumentContract].
          */
-        fun registerForActivityResult(activity: AppCompatActivity) {
+        fun registerForActivityResult(activity: ComponentActivity) {
             startForResult = activity.registerForActivityResult(PickDocumentContract()) { uri ->
                 if (uri != null && !PickDocumentContract.isAcceptableBimUri(uri)) {
                     MainScope().launch {

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/ExternalFiles.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/ExternalFiles.kt
@@ -28,10 +28,11 @@ fun ContentResolver.getDisplayName(uri: Uri): String? {
  * Copies the input uri to the destination directory.
  * @param uri The input content Uri to copy.
  * @param destDir The destination directory.
+ * @param uriDisplayName The optional display name for the uri.
  * @return The full path of the copied file, null if it failed.
  */
-fun Context.copyToExternalFiles(uri: Uri, destDir: String): String? {
-    return contentResolver.getDisplayName(uri)?.let { displayName ->
+fun Context.copyToExternalFiles(uri: Uri, destDir: String, uriDisplayName: String? = null): String? {
+    return (uriDisplayName ?: contentResolver.getDisplayName(uri))?.let { displayName ->
         getExternalFilesDir(null)?.let { filesDir ->
             contentResolver.openInputStream(uri)?.use { input ->
                 val outDir = File(filesDir.path, destDir)

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/MainActivity.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/MainActivity.kt
@@ -22,12 +22,7 @@ import kotlin.system.exitProcess
 /**
  * The main activity for the application.
  */
-class MainActivity : AppCompatActivity() {
-    companion object {
-        var current: MainActivity? = null
-            private set
-    }
-
+open class MainActivity : AppCompatActivity() {
     private val sampleITMApplication: SampleITMApplication
         get() {
             @Suppress("UNCHECKED_CAST")
@@ -48,12 +43,10 @@ class MainActivity : AppCompatActivity() {
         MainScope().launch {
             itmApp.waitForFrontendInitialize()
             itmApp.attachWebView(modelWebViewContainer)
-            current = this@MainActivity
         }
     }
 
     override fun onDestroy() {
-        current = null
         modelWebViewContainer.removeAllViews()
         super.onDestroy()
     }

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/MainActivity.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/MainActivity.kt
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 package com.bentley.sample.shared
 
-import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Bundle
 import android.view.ViewGroup
@@ -16,7 +15,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-import com.github.itwin.mobilesdk.ITMApplication
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlin.system.exitProcess
@@ -25,6 +23,11 @@ import kotlin.system.exitProcess
  * The main activity for the application.
  */
 class MainActivity : AppCompatActivity() {
+    companion object {
+        var current: MainActivity? = null
+            private set
+    }
+
     private val sampleITMApplication: SampleITMApplication
         get() {
             @Suppress("UNCHECKED_CAST")
@@ -35,22 +38,22 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val itmApp = sampleITMApplication
-        itmApp.onCreateActivity(this)
+        itmApp.initializeFrontend(this, true)
         supportRequestWindowFeature(Window.FEATURE_NO_TITLE)
         super.onCreate(savedInstanceState)
         setupWebView()
         setupFullScreen()
         hideSystemBars()
         setContentView(R.layout.activity_main)
-        itmApp.initializeFrontend(this, true)
         MainScope().launch {
             itmApp.waitForFrontendInitialize()
             itmApp.attachWebView(modelWebViewContainer)
-            itmApp.onRegisterNativeUI()
+            current = this@MainActivity
         }
     }
 
     override fun onDestroy() {
+        current = null
         modelWebViewContainer.removeAllViews()
         super.onDestroy()
     }
@@ -77,7 +80,6 @@ class MainActivity : AppCompatActivity() {
     private fun setupFullScreen() {
         // Truly full screen (including camera cutouts)
         window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.statusBarColor = Color.TRANSPARENT
     }
@@ -90,13 +92,7 @@ class MainActivity : AppCompatActivity() {
         windowInsetsController.hide(systemBars())
     }
 
-    override fun onPause() {
-        sampleITMApplication.onPause()
-        super.onPause()
-    }
-
     override fun onResume() {
-        sampleITMApplication.onResume()
         setupFullScreen()
         super.onResume()
     }

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/PickUriContract.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/PickUriContract.kt
@@ -42,6 +42,16 @@ open class PickUriContract(@Suppress("MemberVisibilityCanBePrivate") var destDir
     }
 
     /**
+     * Gets the display name (base name with extension) for the input Uri.
+     * By default the context's content resolver is used to get the display name.
+     * @param uri The Uri to get the display name for.
+     * @return The display name.
+     */
+    open fun getDisplayName(uri: Uri): String {
+        return context.contentResolver.getDisplayName(uri) ?: "unknownDisplayName"
+    }
+
+    /**
      * If the resultCode equals RESULT_OK, the chosen Uri is either returned or copied. When
      * copied, a content Uri is returned.
      * @param resultCode The result code.
@@ -51,7 +61,7 @@ open class PickUriContract(@Suppress("MemberVisibilityCanBePrivate") var destDir
         val uri = intent?.takeIf { resultCode == Activity.RESULT_OK }?.data
         if (uri != null && shouldCopyUri(uri)) {
             destDir?.let { destDir ->
-                context.copyToExternalFiles(uri, destDir)?.let { result ->
+                context.copyToExternalFiles(uri, destDir, getDisplayName(uri))?.let { result ->
                     return Uri.parse(result)
                 }
             }

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/SampleITMApplication.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/SampleITMApplication.kt
@@ -5,17 +5,13 @@
 package com.bentley.sample.shared
 
 import android.content.Context
-import android.net.Uri
 import android.webkit.WebView
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.eclipsesource.json.Json
 import com.eclipsesource.json.JsonValue
-import com.github.itwin.mobilesdk.ITMApplication
-import com.github.itwin.mobilesdk.ITMLogger
-import com.github.itwin.mobilesdk.ITMMessenger
-import com.github.itwin.mobilesdk.ITMOIDCAuthorizationClient
+import com.github.itwin.mobilesdk.*
 import com.github.itwin.mobilesdk.jsonvalue.getOptionalString
 import com.github.itwin.mobilesdk.jsonvalue.isYes
 import kotlinx.coroutines.MainScope
@@ -71,31 +67,26 @@ open class SampleITMApplication(context: Context, attachWebViewLogger: Boolean, 
     /**
      * Registers activity result handlers for our native UI components.
      */
-    open fun onCreateActivity(activity: AppCompatActivity) {
+    protected open fun onCreateActivity(activity: ComponentActivity) {
         DocumentPicker.registerForActivityResult(activity)
     }
 
     /**
      * Registers our native UI components.
      */
-    open fun onRegisterNativeUI() {
-        nativeUI?.let {
-            it.components.add(DocumentPicker(it))
+    protected open fun onRegisterNativeUI() {
+        nativeUI?.apply {
+            components.add(DocumentPicker(this))
         }
     }
 
     /**
-     * Notifies the IModelJsHost that the app has paused.
+     * Override createNativeUI so we can also register our own native components.
      */
-    fun onPause() {
-        this.host?.onPause()
-    }
-
-    /**
-     * Notifies the IModelJsHost that the app has resumed.
-     */
-    fun onResume() {
-        this.host?.onResume()
+    override fun createNativeUI(context: Context): ITMNativeUI? {
+        return super.createNativeUI(context)?.also {
+            onRegisterNativeUI()
+        }
     }
 
     override fun initializeBackend(allowInspectBackend: Boolean) {
@@ -116,18 +107,11 @@ open class SampleITMApplication(context: Context, attachWebViewLogger: Boolean, 
         }
     }
 
-    fun associateWithActivity(activity: AppCompatActivity) {
+    override fun associateWithActivity(activity: ComponentActivity) {
+        super.associateWithActivity(activity)
         activity.lifecycle.addObserver(object: DefaultLifecycleObserver {
             override fun onCreate(owner: LifecycleOwner) {
                 onCreateActivity(activity)
-            }
-
-            override fun onPause(owner: LifecycleOwner) {
-                this@SampleITMApplication.onPause()
-            }
-
-            override fun onResume(owner: LifecycleOwner) {
-                this@SampleITMApplication.onResume()
             }
         })
     }

--- a/Android/Shared/src/main/java/com/bentley/sample/shared/SampleITMApplication.kt
+++ b/Android/Shared/src/main/java/com/bentley/sample/shared/SampleITMApplication.kt
@@ -74,10 +74,8 @@ open class SampleITMApplication(context: Context, attachWebViewLogger: Boolean, 
     /**
      * Registers our native UI components.
      */
-    protected open fun onRegisterNativeUI() {
-        nativeUI?.apply {
-            components.add(DocumentPicker(this))
-        }
+    protected open fun onRegisterNativeUI(nativeUI: ITMNativeUI) {
+        nativeUI.components.add(DocumentPicker(nativeUI))
     }
 
     /**
@@ -85,7 +83,7 @@ open class SampleITMApplication(context: Context, attachWebViewLogger: Boolean, 
      */
     override fun createNativeUI(context: Context): ITMNativeUI? {
         return super.createNativeUI(context)?.also {
-            onRegisterNativeUI()
+            onRegisterNativeUI(it)
         }
     }
 

--- a/Android/iTwinStarter/.idea/detekt.xml
+++ b/Android/iTwinStarter/.idea/detekt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DetektPluginSettings">
+    <option name="enableDetekt" value="false" />
+  </component>
+</project>

--- a/ReactNative/iTwinRNStarter/android/app/build.gradle
+++ b/ReactNative/iTwinRNStarter/android/app/build.gradle
@@ -162,7 +162,7 @@ dependencies {
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation 'androidx.core:core-ktx:1.10.0'
-    implementation project(path: ':itmsamplesshared')
+    implementation project(path: ':ITMSamplesShared')
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
@@ -181,4 +181,4 @@ dependencies {
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle")
 apply plugin: 'org.jetbrains.kotlin.android'; applyNativeModulesAppBuildGradle(project)
 
-preBuild.dependsOn(":itmsamplesshared:genITMAppConfig", ":itmsamplesshared:copyITMAssets")
+preBuild.dependsOn(":ITMSamplesShared:genITMAppConfig", ":ITMSamplesShared:copyITMAssets")

--- a/ReactNative/iTwinRNStarter/android/app/src/main/java/com/bentley/itwinrnstarter/MainActivity.kt
+++ b/ReactNative/iTwinRNStarter/android/app/src/main/java/com/bentley/itwinrnstarter/MainActivity.kt
@@ -4,9 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 package com.bentley.itwinrnstarter
 
-import android.annotation.SuppressLint
-import android.os.Bundle
-import android.os.PersistableBundle
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.OnHierarchyChangeListener
@@ -35,10 +32,6 @@ class MainActivity: ReactActivity() {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
-        super.onCreate(savedInstanceState, persistentState)
-    }
-
     override fun setContentView(view: View?) {
         itmApplication.associateWithActivity(this)
         super.setContentView(view)
@@ -50,7 +43,6 @@ class MainActivity: ReactActivity() {
                     itmApplication.initializeFrontend(this@MainActivity, false, child)
                     MainScope().launch {
                         itmApplication.waitForFrontendInitialize()
-                        itmApplication.onRegisterNativeUI()
                     }
                 }
             }

--- a/ReactNative/iTwinRNStarter/android/settings.gradle
+++ b/ReactNative/iTwinRNStarter/android/settings.gradle
@@ -27,9 +27,9 @@ dependencyResolutionManagement {
         }
     }
 }
-rootProject.name = 'com.bentley.itwinrnstarter'
+rootProject.name = 'iTwin RN Starter'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
 includeBuild('../node_modules/react-native-gradle-plugin')
-include ':itmsamplesshared'
-project(':itmsamplesshared').projectDir = new File('../../../Android/Shared')
+include ':ITMSamplesShared'
+project(':ITMSamplesShared').projectDir = new File('../../../Android/Shared')


### PR DESCRIPTION
This started as some refactoring in SampleITMApplication but then grew larger when I realized that the CameraSample was broken.

**Note:** this PR relies on [Added pause/resume functionality](https://github.com/iTwin/mobile-sdk-android/pull/56) in mobile-sdk-android

# Changes Summary
## Shared
- DocumentPicker
    - Changed registerForActivityResult to take a ComponentActivity instead of AppCompatActivity (trickle down from SampleITMApplication.associateWithActivity now being a proper override)
- ExternalFiles
    - Restored optional display name functionality to copyToExternalFiles function as it was missing and needed by the CameraSample
- MainActivity
    - Moved initializeFrontend call to start of onCreate and removed onCreateActivity as that's called automatically now by SampleITMApplication's association with the activity
    - Removed onPause as that's now done in mobile-sdk-android
    - Removed sampleITMApplication.onResume from onResume as that's now done in mobile-sdk-android
- PickUriContract
    - Restored getDisplayName function and now uses it in the copyToExternalFiles call (again so CameraSample will work)
- SampleITMApplication
    - Changed onCreateActivity to take a ComponentActivity as it's called by the associateWithActivity override
    - onRegisterNativeUI is now protected as it's only called within SampleITMApplication
    - Added createNativeUI override that calls onRegisterNativeUI
    - Removed onPause and onResume overrides as that's now done in mobile-sdk-android
    - associateWithActivity
        - Fixed it to override the base class!
        - Removed onPause and onResume
## CameraSample
- CameraApplication
    - Made it a SampleApplicationBase sub-class
    - Added instance companion object so it can be used statically by ImageCache
- CameraITMApplication
    - Now an open class instead of an object (so we can use it with SampleApplicationBase)
    - Removed init (as that goes in the object)
    - Changed onCreateActivity to match new signature
    - Changed onRegisterNativeUI to match new signature
- CameraMainActivity
    - MainActivity subclass that adds a `current` var in the companion object as it is used by ImageCache
- ImageCache
    - CameraApplication.instance.applicationContext instead of CameraITMApplication.appContext
    - CameraApplication.instance.itmApplication instead of CameraITMApplication
    - CameraMainActivity.current instead of MainActivity.current
- ImagePicker
    - Changed registerForActivityResult to take a ComponentActivity
## iTwinRNStarter
- MainActivity
    - Removed onCreate override as it wasn't doing anything
    - Removed itmApplication.onRegisterNativeUI call as it's now done automatically
