### PR TITLE
Camera sample code cleanup:

### DIFF
--- a/cross-platform/react-app/src/frontend/CameraSample/CameraSampleApp.tsx
+++ b/cross-platform/react-app/src/frontend/CameraSample/CameraSampleApp.tsx
@@ -13,6 +13,17 @@ import {
   PictureView,
 } from "./Exports";
 
+/**
+ * Look up a localized string in the `CameraSampleApp` i18n namespace.
+ *
+ * __Note__: If debugI18n is set to true in the app URL, the localized string has an equals sign
+ * added to both the front and back. (For example, "About" becomes "=About=").
+ *
+ * @param prefix The prefix of (top-level group) for the localized string.
+ * @param key The name of the localized string.
+ * @param options Optional options to pass to `getLocalizedString`.
+ * @returns The given localized string.
+ */
 export function CameraSampleAppGetLocalizedString(prefix: string, key: string, options?: any) {
   if (window.itmSampleParams.debugI18n) {
     return `=${IModelApp.localization.getLocalizedString(`CameraSampleApp:${prefix}.${key}`, options)}=`;
@@ -21,6 +32,7 @@ export function CameraSampleAppGetLocalizedString(prefix: string, key: string, o
   }
 }
 
+/** React component to show a marker image when it is selected. */
 function ImageSelectionHandler() {
   const [selectedPictureUrl, setSelectedPictureUrl] = React.useState<string>();
 
@@ -31,6 +43,7 @@ function ImageSelectionHandler() {
   }} /> : null;
 }
 
+/** Top-level React component for the camera sample app. */
 export function CameraSampleApp() {
   return <App
     onInitialize={async () => {

--- a/cross-platform/react-app/src/frontend/CameraSample/CameraSampleToolsBottomPanel.tsx
+++ b/cross-platform/react-app/src/frontend/CameraSample/CameraSampleToolsBottomPanel.tsx
@@ -15,17 +15,27 @@ import {
 } from "./Exports";
 import { Point3d } from "@itwin/core-geometry";
 
+/**
+ * Select and then add an image marker to the given iModel at the given location.
+ * @param point The 3D location of the image marker in the iModel.
+ * @param photoLibrary Whether or not to pick the image from the photo library (true) or use the
+ * camera (false).
+ * @param iModelId The iModelId of the iModel to which to add the image marker.
+ */
 const addImageMarker = async (point: Point3d, photoLibrary: boolean, iModelId: string) => {
   const fileUrl = await ImageCache.pickImage(iModelId, photoLibrary);
   if (fileUrl)
     void ImageMarkerApi.addMarker(point, fileUrl);
 };
 
+/**
+ * {@link PlaceMarkerTool} to allow the user to select a location in the model, then place a marker
+ * image from the photo gallery into that location.
+ */
 class PlacePhotoMarkerTool extends PlaceMarkerTool {
-  public static toolId = "PlacePhotoMarkerTool";
-  public static iconSpec = "icon-image";
-  public static prompt = "";
-  public static enableSnap = false;
+  public static override toolId = "PlacePhotoMarkerTool";
+  public static override iconSpec = "icon-image";
+  public static override prompt = "";
 
   constructor(iModelId: string) {
     super(async (point: Point3d) => {
@@ -36,11 +46,14 @@ class PlacePhotoMarkerTool extends PlaceMarkerTool {
   }
 }
 
+/**
+ * {@link PlaceMarkerTool}  to allow the user to select a location in the model, then place a marker
+ * image taken from camera into that location.
+ */
 class PlaceCameraMarkerTool extends PlaceMarkerTool {
-  public static toolId = "PlaceCameraMarkerTool";
-  public static iconSpec = "icon-camera";
-  public static prompt = "";
-  public static enableSnap = false;
+  public static override toolId = "PlaceCameraMarkerTool";
+  public static override iconSpec = "icon-camera";
+  public static override prompt = "";
 
   constructor(iModelId: string) {
     super(async (point: Point3d) => {
@@ -51,6 +64,7 @@ class PlaceCameraMarkerTool extends PlaceMarkerTool {
   }
 }
 
+/** {@link ToolsBottomPanel} React component with extra camera sample-specific tools added. */
 export function CameraSampleToolsBottomPanel(props: ToolsBottomPanelProps) {
   const { iModel } = props;
   const tools = React.useMemo(() => {
@@ -71,7 +85,11 @@ export function CameraSampleToolsBottomPanel(props: ToolsBottomPanelProps) {
     if (!IModelApp.tools.find(PlaceCameraMarkerTool.toolId))
       IModelApp.tools.register(PlaceCameraMarkerTool, "CameraSampleApp");
 
-    ImageMarkerApi.startup(iModel.iModelId);
+    if (iModel.iModelId) {
+      ImageMarkerApi.startup(iModel.iModelId);
+    } else {
+      ImageMarkerApi.shutdown();
+    }
 
     return () => {
       ImageMarkerApi.shutdown();

--- a/cross-platform/react-app/src/frontend/CameraSample/PlaceMarkerTool.ts
+++ b/cross-platform/react-app/src/frontend/CameraSample/PlaceMarkerTool.ts
@@ -11,12 +11,15 @@ import {
 } from "@itwin/core-frontend";
 import { Point3d } from "@itwin/core-geometry";
 
+/**
+ * {@link PrimitiveTool} to allow the user to select a location in the model, then place a marker
+ * image from the either the photo gallery or camera into that location.
+ */
 export class PlaceMarkerTool extends PrimitiveTool {
   // Sub-classes can override these properties
-  public static toolId = "PlaceMarkerTool";
-  public static iconSpec = "icon-location";
+  public static override toolId = "PlaceMarkerTool";
+  public static override iconSpec = "icon-location";
   public static prompt = "Enter point";
-  public static enableSnap = true;
 
   protected _createMarkerCallback: (pt: Point3d) => {};
 
@@ -25,27 +28,26 @@ export class PlaceMarkerTool extends PrimitiveTool {
     this._createMarkerCallback = callback;
   }
 
-  public get ctor() { return this.constructor as typeof PlaceMarkerTool; }
-  public isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean { return (super.isCompatibleViewport(vp, isSelectedViewChange) && undefined !== vp); }
-  public isValidLocation(_ev: BeButtonEvent, _isButtonEvent: boolean): boolean { return true; } // Allow clicking anywhere
-  public requireWriteableTarget(): boolean { return false; } // Tool doesn't modify the imodel.
-  public async onPostInstall() { await super.onPostInstall(); this.setupAndPromptForNextAction(); }
-  public async onRestartTool() { await this.exitTool(); }
-
-  protected setupAndPromptForNextAction(): void {
-    if (this.ctor.enableSnap)
-      IModelApp.accuSnap.enableSnap(true);
+  public override get ctor() { return this.constructor as typeof PlaceMarkerTool; }
+  public override isCompatibleViewport(vp: Viewport | undefined, isSelectedViewChange: boolean): boolean {
+    return (super.isCompatibleViewport(vp, isSelectedViewChange) && undefined !== vp);
+  }
+  public override isValidLocation(_ev: BeButtonEvent, _isButtonEvent: boolean): boolean { return true; } // Allow clicking anywhere
+  public override requireWriteableTarget(): boolean { return false; } // Tool doesn't modify the imodel.
+  public override async onPostInstall() {
+    await super.onPostInstall();
     IModelApp.notifications.setToolAssistance(ToolAssistance.createInstructions(ToolAssistance.createInstruction(this.iconSpec, this.ctor.prompt)));
   }
+  public async onRestartTool() { await this.exitTool(); }
 
-  // A reset button is the secondary action button, ex. right mouse button.
-  public async onResetButtonUp(_ev: BeButtonEvent): Promise<EventHandled> {
+  // A reset button is the secondary action button, ex. right mouse button or two-finger tap.
+  public override async onResetButtonUp(_ev: BeButtonEvent): Promise<EventHandled> {
     void this.onReinitialize(); // Calls onRestartTool to exit
     return EventHandled.No;
   }
 
-  // A data button is the primary action button, ex. left mouse button.
-  public async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
+  // A data button is the primary action button, ex. left mouse button or one-finger tap.
+  public override async onDataButtonDown(ev: BeButtonEvent): Promise<EventHandled> {
     if (undefined === ev.viewport)
       return EventHandled.No; // Shouldn't really happen
 

--- a/cross-platform/react-app/src/frontend/CameraSample/Support/ImageCache.ts
+++ b/cross-platform/react-app/src/frontend/CameraSample/Support/ImageCache.ts
@@ -8,8 +8,10 @@ export class ImageCache {
   /**
    * Get an image, either by taking a camera picture, or picking one from the photo library.
    * @param iModelId The iModelId to associate the image with.
-   * @param photoLibrary true to pick from the photo library, or false to take a new picture with the camera, default is false.
-   * @returns The URL of the newly picked image.
+   * @param photoLibrary true to pick from the photo library, or false to take a new picture with
+   * the camera, default is false.
+   * @returns A string containing the URL of the newly picked image, or undefined if the user
+   * cancels.
    */
   public static async pickImage(iModelId: string | undefined, photoLibrary = false): Promise<string | undefined> {
     return Messenger.query("pickImage", { iModelId, sourceType: photoLibrary ? "photoLibrary" : "camera" });
@@ -17,7 +19,10 @@ export class ImageCache {
 
   /**
    * Delete images from the image cache.
-   * @param urls An array of URL's of the images to delete.
+   *
+   * __Note__: Also removes any markers that show the given images.
+   *
+   * @param urls An array of URLs of the images to delete.
    * @returns A void Promise that completes when the deletion has finished.
    */
   public static async deleteImages(urls: string[]): Promise<void> {
@@ -27,10 +32,13 @@ export class ImageCache {
 
   /**
    * Delete all cached images associated with a specific iModel.
+   *
+   * __Note__: Also removes any markers for the given iModel.
+   *
    * @param iModelId The iModelId to delete the cached images from.
    * @returns A void Promise that completes when the deletion has finished.
    */
-  public static async deleteAllImages(iModelId: string | undefined): Promise<void> {
+  public static async deleteAllImages(iModelId: string): Promise<void> {
     ImageMarkerApi.deleteMarkers(iModelId);
     return Messenger.query("deleteAllImages", { iModelId });
   }
@@ -45,7 +53,7 @@ export class ImageCache {
   }
 
   /**
-   * Share images from the image cache.
+   * Share images from the image cache using the OS-specific sharing mechanism.
    * @param urls An array of URL's of the images to share.
    * @returns A void Promise that completes when the share dialog is displayed.
    */


### PR DESCRIPTION
* Improved commenting
* Use tryImageElementFromUrl from iTwin
* Add override keyword where appropriate
* Remove enabled param from ImageMarkerAPI.startup.
* Fix bug when disabling and then enabling markers.
* Require an iModelId for operations that affect "all" images
* Remove unused enableSnap from maker tools
* Move remaining line from PlaceMarkerTool.setupAndPromptForNextAction into onPostInstall