### PR TITLE
iOS Camera Sample code cleanup:

### DIFF
--- a/cross-platform/react-app/src/frontend/CameraSample/PicturesBottomPanel.tsx
+++ b/cross-platform/react-app/src/frontend/CameraSample/PicturesBottomPanel.tsx
@@ -68,7 +68,9 @@ export function PicturesBottomPanel(props: PicturesBottomPanelProps) {
 
   // Reload the list of attached pictures.
   const reload = React.useCallback(async () => {
-    const urls = await ImageCache.getImages(iModel.iModelId);
+    // Note: We only allow loading iModels, not creating them, so our iModel is guaranteed to have
+    // an iModelId.
+    const urls = await ImageCache.getImages(iModel.iModelId!);
     urls.sort();
     setPictureUrls(urls);
     if (urls.length === 0) {
@@ -155,12 +157,16 @@ export function PicturesBottomPanel(props: PicturesBottomPanelProps) {
         }} />}
       {!selectMode && <>
         <ToolButton iconSpec={"icon-camera"} onClick={async () => {
-          if (await ImageCache.pickImage(iModel.iModelId)) {
+          // Note: We only allow loading iModels, not creating them, so our iModel is guaranteed to
+          // have an iModelId.
+          if (await ImageCache.pickImage(iModel.iModelId!)) {
             void reload();
           }
         }} />
         <ToolButton iconSpec={"icon-image"} onClick={async () => {
-          if (await ImageCache.pickImage(iModel.iModelId, true)) {
+          // Note: We only allow loading iModels, not creating them, so our iModel is guaranteed to
+          // have an iModelId.
+          if (await ImageCache.pickImage(iModel.iModelId!, true)) {
             void reload();
           }
         }} />
@@ -188,9 +194,9 @@ export function PicturesBottomPanel(props: PicturesBottomPanelProps) {
           onClick={async () => {
             const all = pictureUrls.length === selectedUrls.size;
             if (all && await presentYesNoAlert(deleteAllTitle, deleteAllMessage, true)) {
-              if (iModel.iModelId) {
-                await ImageCache.deleteAllImages(iModel.iModelId);
-              }
+              // Note: We only allow loading iModels, not creating them, so our iModel is guaranteed
+              // to have an iModelId.
+              await ImageCache.deleteAllImages(iModel.iModelId!);
               void reload();
             } else if (!all && await presentYesNoAlert(deleteSelectedTitle, deleteSelectedMessage, true)) {
               await ImageCache.deleteImages(Array.from(selectedUrls));

--- a/cross-platform/react-app/src/frontend/CameraSample/Support/ImageCache.ts
+++ b/cross-platform/react-app/src/frontend/CameraSample/Support/ImageCache.ts
@@ -13,7 +13,7 @@ export class ImageCache {
    * @returns A string containing the URL of the newly picked image, or undefined if the user
    * cancels.
    */
-  public static async pickImage(iModelId: string | undefined, photoLibrary = false): Promise<string | undefined> {
+  public static async pickImage(iModelId: string, photoLibrary = false): Promise<string | undefined> {
     return Messenger.query("pickImage", { iModelId, sourceType: photoLibrary ? "photoLibrary" : "camera" });
   }
 
@@ -48,7 +48,7 @@ export class ImageCache {
    * @param iModelId The iModelId to get the images for.
    * @returns A Promise that resolves to an array of strings representing all the image URLs.
    */
-  public static async getImages(iModelId: string | undefined): Promise<string[]> {
+  public static async getImages(iModelId: string): Promise<string[]> {
     return Messenger.query("getImages", { iModelId });
   }
 

--- a/iOS/CameraSample/CameraSample/CamModelApplication.swift
+++ b/iOS/CameraSample/CameraSample/CamModelApplication.swift
@@ -11,8 +11,8 @@ import ITwinMobile
 /// that is specific to this sample.
 class CamModelApplication: ModelApplication {
     /// Registers query handlers.
-    required init() {
-        super.init()
+    override func registerQueryHandlers() {
+        super.registerQueryHandlers()
         registerQueryHandler("getImages", ImageCache.handleGetImages)
         registerQueryHandler("deleteAllImages", ImageCache.handleDeleteAllImages)
         registerQueryHandler("deleteImages", ImageCache.handleDeleteImages)
@@ -29,7 +29,9 @@ class CamModelApplication: ModelApplication {
             itmNativeUI.addComponent(ImageSharer(itmNativeUI: itmNativeUI))
         }
     }
-
+    
+    /// Update the web view configuration to include our custom URL scheme handler for images.
+    /// - Parameter configuration: The `WKWebViewConfiguration` that is about to be applied to our `WKWebView`.
     override class func updateWebViewConfiguration(_ configuration: WKWebViewConfiguration) {
         configuration.setURLSchemeHandler(ImageCacheSchemeHandler(), forURLScheme: ImageCacheSchemeHandler.urlScheme)
     }

--- a/iOS/CameraSample/CameraSample/ImageCache.swift
+++ b/iOS/CameraSample/CameraSample/ImageCache.swift
@@ -8,7 +8,9 @@ import ITwinMobile
 
 /// Class for interacting with the image cache.
 class ImageCache {
-    /// Get all the images for a given iModel
+    /// Get all the images for a given iModel.
+    ///
+    /// This is a handler for the `'getImages'` query.
     /// - Parameter params: Requires an `iModelId` property to specify which iModel to get images for.
     /// - Returns: An array of image cache URLs for all the images in the cache for the given iModel
     static func handleGetImages(params: [String: Any]) -> [String] {
@@ -29,6 +31,8 @@ class ImageCache {
     }
     
     /// Deletes all the images in the cache for the given iModel.
+    ///
+    /// This is a handler for the `'deleteAllImages'` query.
     /// - Parameter params: Requires an `iModelId` property to specify which iModel to delete images for.
     static func handleDeleteAllImages(params: [String: Any]) {
         guard let iModelId = params["iModelId"] as? String, let dirURL = baseURL?.appendingPathComponent(iModelId) else {
@@ -45,6 +49,8 @@ class ImageCache {
         }
     }
     
+    /// Delete the image referenced by the given image cache URL.
+    /// - Parameter urlString: URL using camera sample's custom URL scheme to reference a cached image to be deleted.
     private static func deleteImage(urlString: String) {
         if let fileUrl = getFileUrl(URL(string: urlString)) {
             do {
@@ -53,8 +59,10 @@ class ImageCache {
         }
     }
     
-    /// Deletes a specific image cache image.
-    /// - Parameter params: Requires a `urls` property containing a string or array of strings with the image cache URL's to delete.
+    /// Deletes specific image cache images.
+    ///
+    /// This is a handler for the `'deleteImages'` query.
+    /// - Parameter params: Requires a `urls` property containing a string or array of strings with the image cache URLs to delete.
     static func handleDeleteImages(params: [String: Any]) {
         if let urls = params["urls"] as? [String] {
             for url in urls {

--- a/iOS/CameraSample/CameraSample/ImageSharer.swift
+++ b/iOS/CameraSample/CameraSample/ImageSharer.swift
@@ -6,7 +6,7 @@
 import UIKit
 import ITwinMobile
 
-/// An `ITMNativeUIComponent` subclass for one or more pictures by URL.
+/// An `ITMNativeUIComponent` subclass for sharing one or more pictures by URL.
 class ImageSharer: ITMNativeUIComponent {
     override init(itmNativeUI: ITMNativeUI) {
         super.init(itmNativeUI: itmNativeUI)
@@ -15,10 +15,10 @@ class ImageSharer: ITMNativeUIComponent {
     
     /// Simple wrapper for sharing anything via the `UIActivityViewController`.
     /// - Parameters:
-    ///   - items: The items to share.
+    ///   - items: The items to share. The URLs are file URLs representing images in the image cache.
     ///   - vc: The view controller used to present the sharing UI.
     ///   - sourceRect: The rectangle in the coordinate space of `vc` that the popover should point at.
-    static func shareItems(items: [Any], vc: UIViewController, sourceRect: CGRect) {
+    static func shareItems(items: [URL], vc: UIViewController, sourceRect: CGRect) {
         let shareActivity = UIActivityViewController(activityItems: items, applicationActivities: nil)
         if let popover = shareActivity.popoverPresentationController {
             popover.sourceView = vc.view
@@ -27,7 +27,7 @@ class ImageSharer: ITMNativeUIComponent {
         vc.present(shareActivity, animated: true)
     }
     
-    /// Handles the shareImages message.
+    /// Handles the `"shareImages"` query.
     /// - Parameter params: The input params from JavaScript. This must contain a `urls` array string property.
     /// It can optionally also contain a `sourceRect` proprty that indicates the screen component this share action
     /// corresponds with. It is expected to be a javascript object with the same properties in ITMRect.

--- a/iOS/Shared/ModelApplication.swift
+++ b/iOS/Shared/ModelApplication.swift
@@ -36,7 +36,7 @@ class ModelApplication: ITMApplication {
     }
 
     /// Registers query handlers.
-    private func registerQueryHandlers() {
+    open func registerQueryHandlers() {
         registerQueryHandler("didFinishLaunching") { (params: [String: Any]) -> Void in
             self.itmMessenger.frontendLaunchSucceeded()
             self.finishRecordingStartupTimes(params["iTwinVersion"] as? String)


### PR DESCRIPTION
* Improved commenting
* Make iModelId required in pickImage and getImages
* Make registerQueryHandlers virtual and use that in CamModelApplication
* Store picker in ImagePicker and cancel previous pick request before starting a new one
* Update `items` parameter of `ImageSharer.shareItems` to be an array of URLs.