### PR TITLE
Copy @itwin/core-backend assets into built app

### DIFF
--- a/Android/Shared/ITMAssets.gradle
+++ b/Android/Shared/ITMAssets.gradle
@@ -27,6 +27,7 @@ task copyITMAssets {
             "${reactAppDir}/build": "${assetsDir}/frontend",
             "${reactAppDir}/lib/webpack": "${assetsDir}/backend",
             "${reactAppDir}/assets": "${assetsDir}/backend/assets",
+            "${reactAppDir}/node_modules/@itwin/core-backend/lib/cjs/assets": "${assetsDir}/backend/assets",
             "${reactAppDir}/node_modules/@itwin/presentation-backend/lib/cjs/assets/supplemental-presentation-rules": "${assetsDir}/backend/assets/supplemental_presentation_rules",
             "${reactAppDir}/node_modules/@itwin/presentation-common/lib/cjs/assets/locales": "${assetsDir}/backend/assets/locales"
         ]

--- a/Android/Shared/ITMAssets.gradle
+++ b/Android/Shared/ITMAssets.gradle
@@ -19,9 +19,10 @@ static def copyDirectory(srcDir, destDir) {
 task copyITMAssets {
     doLast {
         def reactAppDir = "${projectDir}/../../cross-platform/react-app"
-        println "reactAppDir ${new File(reactAppDir).canonicalPath}"
+        println "Copying assets."
+        println "reactAppDir: ${new File(reactAppDir).canonicalPath}"
         def assetsDir = "${rootDir}/app/src/main/assets/ITMApplication"
-        println "assetsDir ${new File(assetsDir).canonicalPath}"
+        println "assetsDir: ${new File(assetsDir).canonicalPath}"
 
         Map foldersToCopy = [
             "${reactAppDir}/build": "${assetsDir}/frontend",
@@ -39,6 +40,7 @@ task copyITMAssets {
 
 task cleanITMAssets {
     def assetsDir = "${rootDir}/app/src/main/assets/ITMApplication"
-    println "assetsDir ${new File(assetsDir).canonicalPath}"
+    println "Cleaning assets."
+    println "assetsDir: ${new File(assetsDir).canonicalPath}"
     project.delete(files(assetsDir))
 }

--- a/Android/Shared/ITMAssets.gradle
+++ b/Android/Shared/ITMAssets.gradle
@@ -36,3 +36,9 @@ task copyITMAssets {
             copyDirectory(Paths.get(entry.key), Paths.get(entry.value))
     }
 }
+
+task cleanITMAssets {
+    def assetsDir = "${rootDir}/app/src/main/assets/ITMApplication"
+    println "assetsDir ${new File(assetsDir).canonicalPath}"
+    project.delete(files(assetsDir))
+}

--- a/Android/iTwinStarter/app/build.gradle
+++ b/Android/iTwinStarter/app/build.gradle
@@ -53,3 +53,4 @@ dependencies {
 }
 
 preBuild.dependsOn(":itmsamplesshared:genITMAppConfig", ":itmsamplesshared:copyITMAssets")
+clean.dependsOn(":itmsamplesshared:cleanITMAssets")

--- a/cross-platform/react-app/assets/Settings/Schemas/dummy.txt
+++ b/cross-platform/react-app/assets/Settings/Schemas/dummy.txt
@@ -1,1 +1,0 @@
-Do not delete this file.

--- a/cross-platform/react-app/webpack.config.js
+++ b/cross-platform/react-app/webpack.config.js
@@ -42,6 +42,13 @@ function getConfig(env) {
     },
     target: "node",
     devtool: devMode ? "cheap-module-source-map" : undefined,
+    // WebPack defaults to using the esm version of json5. The alias below forces it to use cjs.
+    // See: https://github.com/json5/json5/issues/240
+    resolve: {
+      alias: {
+        json5: 'json5/lib/index.js',
+      }
+    },
     // The module rules below cause it to skip certain things. These are things that we
     // don't really use, but trigger exceptions at run-time in their startup
     // initialization.

--- a/iOS/CopyWebAppAssets.sh
+++ b/iOS/CopyWebAppAssets.sh
@@ -25,6 +25,7 @@ rsync -aL --delete "${reactAppDir}/assets/" "$AppBundleRoot/$WebAppDir/backend/a
 
 # must be done after rsync above
 [ -d "$AppBundleRoot/$WebAppDir/backend/assets" ] || mkdir -p "$AppBundleRoot/$WebAppDir/backend/assets"
+rsync -aL "${reactAppDir}/node_modules/@itwin/core-backend/lib/cjs/assets/" "$AppBundleRoot/$WebAppDir/backend/assets/"
 rsync -aL --delete "${reactAppDir}/node_modules/@itwin/presentation-common/lib/cjs/assets/locales/" "$AppBundleRoot/$WebAppDir/backend/assets/locales/"
 rsync -aL --delete "${reactAppDir}/node_modules/@itwin/presentation-backend/lib/cjs/assets/supplemental-presentation-rules/" "$AppBundleRoot/$WebAppDir/backend/assets/supplemental_presentation_rules/"
 


### PR DESCRIPTION
Without this, geolocation doesn't work properly. For the sample app itself, that's not visible, but anyone who uses the sample app as a base will run into problems if they try to geolocate.