### PR TITLE
IconSpec no longer requires a prefix for SVGs.

### DIFF
--- a/cross-platform/react-app/src/frontend/Screens/HomeScreen.tsx
+++ b/cross-platform/react-app/src/frontend/Screens/HomeScreen.tsx
@@ -3,7 +3,6 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import React from "react";
-import { IconSpecUtilities } from "@itwin/appui-abstract";
 import { Messenger } from "@itwin/mobile-sdk-core";
 import { BackButton, IconImage } from "@itwin/mobile-ui-react";
 import { ActiveScreen, Button, Screen, signOut, useLocalizedString } from "../Exports";
@@ -12,9 +11,6 @@ import "./HomeScreen.scss";
 // With svg.d.ts present in the root of this project, Webpack automatically handles the import below
 // by having folderSvg be the path to the name-mangled version of folder.svg.
 import folderSvg from "../Images/folder.svg";
-// IconSpecUtilities.createWebComponentIconSpec takes the SVG path and tweaks it for use in any
-// place that expects an IconSpec.
-const folderIconSpec = IconSpecUtilities.createWebComponentIconSpec(folderSvg);
 
 /**
  *  Properties for {@link HomeScreen} React component.
@@ -49,7 +45,7 @@ export function HomeScreen(props: HomeScreenProps) {
       <div className="list">
         <div className="list-items">
           <Button
-            icon={<IconImage iconSpec={folderIconSpec} margin="0px 8px 0px 0px" size="28px" />}
+            icon={<IconImage iconSpec={folderSvg} margin="0px 8px 0px 0px" size="28px" />}
             title={localModelsLabel}
             onClick={() => onSelect(ActiveScreen.LocalModels)} />
           <Button title={hubIModelsLabel} onClick={() => onSelect(ActiveScreen.Hub)} />


### PR DESCRIPTION
The function that provided that prefix is now deprecated.