### PR TITLE
Remove useFlatConfig setting

### DIFF
--- a/cross-platform/react-app/.vscode/settings.json
+++ b/cross-platform/react-app/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "eslint.experimental.useFlatConfig": true,
     "editor.formatOnSave": true,
     "files.insertFinalNewline": true,
     "cSpell.words": [


### PR DESCRIPTION
This was supposed to be removed when we reverted back to an earlier itwin/eslint-plugin, but got missed